### PR TITLE
Fix estimated total balance value regression (extra stroops division)

### DIFF
--- a/ui/views/explorer/account/account-current-balances-view.js
+++ b/ui/views/explorer/account/account-current-balances-view.js
@@ -15,7 +15,7 @@ export default withErrorBoundary(function AccountCurrentBalancesView({account, o
         {!!valueInfo?.total && <div className="dimmed text-right mobile-left text-small condensed">
             <div className="desktop-only" style={{marginTop: '-2.8em'}}/>
             <span className="mobile-only">Estimated account balances value: </span>
-            ~ {formatWithAutoPrecision(valueInfo.total / 10000000)} <span className="text-tiny">{valueInfo.currency}</span>
+            ~ {formatWithAutoPrecision(valueInfo.total)} <span className="text-tiny">{valueInfo.currency}</span>
             <div className="desktop-only space"/>
         </div>}
         <div className="all-account-balances micro-space text-header">

--- a/ui/views/explorer/contract/contract-balances-view.js
+++ b/ui/views/explorer/contract/contract-balances-view.js
@@ -14,7 +14,7 @@ export default withErrorBoundary(function ContractBalancesView({address, onSelec
         {!!valueInfo?.total && <div className="dimmed text-right mobile-left text-small condensed">
             <div className="desktop-only" style={{marginTop: '-2.8em'}}/>
             <span className="mobile-only">Estimated address balances value: </span>
-            ~ {formatWithAutoPrecision(valueInfo.total / 10000000)} <span
+            ~ {formatWithAutoPrecision(valueInfo.total)} <span
             className="text-tiny">{valueInfo.currency}</span>
             <div className="desktop-only space"/>
         </div>}


### PR DESCRIPTION
## Summary

The estimated total balance value shown in the account view header is currently 10,000,000× smaller than the actual value. This is a regression introduced in 3460254 ("Use server-side fiat values for balances", v0.33.7): that commit removed the client-side stroops division from the per-asset tiles (`account-trustline-balance-view.js`) to match the API now returning fiat values already denominated in the target currency — but the two views that render the summed `total` from the same `/value` endpoint still divide it by 10^7:

- `ui/views/explorer/account/account-current-balances-view.js` (account header total)
- `ui/views/explorer/contract/contract-balances-view.js` (contract header total)

This PR removes the leftover division in both places, so the header estimate matches the sum of the per-asset values.

## Example

https://stellar.expert/explorer/public/account/GC5LF63GRVIT5ZXXCXLPI3RX2YXKJQFZVBSAO6AUELN3YIMSWPD6Z6FH

The header currently shows **~ 12.7 USD**, while the per-asset tiles on the same page show ~10,145,019 USD (XLM) + ~115,771,914 USD (USDC) + ~618,345 USD (VELO) ≈ **126.5M USD**.

<img width="590" height="290" alt="stellar-expert-balance-bug-cropped" src="https://github.com/user-attachments/assets/3290f49a-7f33-4d98-b78c-bad6e16e3319" />

The API response confirms `total` is already in whole currency units, consistent with the per-asset `value` fields:

```json
{
  "balances": [
    {"asset": "XLM", "balance": "564530640165417", "value": 10145019.09},
    {"asset": "USDC-GA5ZSEJY...-1", "balance": "1157755911880369", "value": 115771914.34},
    {"asset": "VELO-GDM4RQUQ...-1", "balance": "1707919667947290", "value": 618345.16}
  ],
  "total": 126535278.59,
  "currency": "USD"
}
```

126,535,278 / 10^7 ≈ 12.65 — exactly the incorrect value displayed.

Smaller accounts show the same issue proportionally (any account's estimate is divided by 10^7).

## Side notes

- The open-source API code in this repo (`api/business-logic/balance/balances.js`, `res.value = Math.floor(price * Number(b.balance))`) still computes stroop-scaled values and doesn't match what the production API returns — may be worth syncing as well.
- The "Report a bug" footer link points to the repo's issue tracker, which has issues disabled — that's why this is filed as a PR without an accompanying issue.
