### PR TITLE
Render contract events in the Interface tab

### DIFF
--- a/views/explorer/contract/contract-interface-view.js
+++ b/views/explorer/contract/contract-interface-view.js
@@ -22,6 +22,20 @@ export function ContractInterfaceView({hash}) {
 
 function parseRustInterface(meta) {
     let res = `// RUST version: ${meta.rustVersion}\n// SDK version: ${meta.sdkVersion}\n\n`
+    if (meta.events) {
+        res += '// EVENTS\n\n'
+        for (const [name, e] of Object.entries(meta.events)) {
+            const attrs = []
+            if (e.prefixTopics?.length) {
+                attrs.push(`topics = [${e.prefixTopics.map(t => `"${t}"`).join(', ')}]`)
+            }
+            attrs.push(`data_format = "${formatEventDataFormat(e.dataFormat)}"`)
+            res += insertDocs(e) + `#[contractevent(${attrs.join(', ')})]\nstruct ${name} {
+${e.params.map(param => insertDocs(param, 1) + (param.location === 'topics' ? indent('#[topic]\n', 1) : '') + indent(param.name, 1) + ': ' + param.type).join(',\n')}
+}\n\n`
+        }
+    }
+
     if (meta.functions) {
         res += '// FUNCTIONS\n\n'
         for (const [name, fn] of Object.entries(meta.functions)) {
@@ -68,6 +82,17 @@ ${Object.entries(meta.errors).map(([name, props]) => insertDocs(props, 1) + inde
 }\n\n`
     }
     return res
+}
+
+function formatEventDataFormat(dataFormat) {
+    switch (dataFormat) {
+        case 'Vec':
+            return 'vec'
+        case 'Map':
+            return 'map'
+        default:
+            return 'single-value'
+    }
 }
 
 function insertDocs(props, level = 0, prefix = '') {

--- a/views/explorer/contract/contract-interface-view.js
+++ b/views/explorer/contract/contract-interface-view.js
@@ -86,12 +86,14 @@ ${Object.entries(meta.errors).map(([name, props]) => insertDocs(props, 1) + inde
 
 function formatEventDataFormat(dataFormat) {
     switch (dataFormat) {
+        case 'SingleValue':
+            return 'single-value'
         case 'Vec':
             return 'vec'
         case 'Map':
             return 'map'
         default:
-            return 'single-value'
+            return dataFormat
     }
 }
 


### PR DESCRIPTION
## What

\`parseContractMetadata()\` (from \`@stellar-expert/contract-wasm-interface-parser\`) already returns an \`events\` section for contracts that use \`#[contractevent]\`, but \`parseRustInterface()\` in \`contract-interface-view.js\` only rendered \`functions\`/\`enums\`/\`structs\`/\`unions\`/\`errors\` — there was no \`if (meta.events)\` branch, so events never showed up in the Interface tab even though the parser already had the data.

This adds an `EVENTS` section, rendered as:

\`\`\`rust
#[contractevent(topics = ["COUNTER", "increment"], data_format = "single-value")]
struct IncrementEvent {
  count: u32
}
\`\`\`

matching soroban-sdk's own `#[contractevent(...)]` macro syntax (static `topics` from `prefixTopics`, `#[topic]` on fields whose `location` is `"topics"`).

## Verification

Deployed the `stellar/soroban-examples` `events` example contract to testnet myself (`CD6MVSXI5QHHWDG5HFZBT227HSC2JKVNU32LGW4YMH6KUL2BIKDKRZD7`) and ran the updated rendering logic against its real, on-chain WASM bytecode. Output now matches what lab.stellar.org's contract explorer already renders for the same contract, which stellar.expert currently omits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)