### PR TITLE
Add Soran testnet name resolution through Stellar RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ pnpm build
 ```
 
 *(check for the generated files in the `./public` repository)*
+
+#### Soran names on testnet
+
+Search for `alice.nova` to see its current destination and required memo. Resolution reads the Universal Lookup contract through Stellar RPC using the existing Stellar SDK. It uses neither the Soran HTTP API nor a Soran SDK.
+
+See [Soran integration and storage format](docs/soran-resolution.md) for the deployment, validation rules, raw ledger keys, and test instructions.

--- a/app-settings.js
+++ b/app-settings.js
@@ -56,6 +56,11 @@ class AppSettings {
             title: 'testnet',
             horizon: 'https://horizon-testnet.stellar.org',
             passphrase: 'Test SDF Network ; September 2015',
+            soran: {
+                rpcUrl: 'https://soroban-testnet.stellar.org',
+                lookupId: 'CDSORANQAJK35UV2HR63CMB6M5NYISHMUBTB6EQY2CZ3Y7HJDIOHRJWA',
+                registryId: 'CCSORANDPQINYOYB5SVO45WJP2LBBYKC72HHUIRVXB4J6RUZKDAUW7G4'
+            },
             demolisher: 'GA4C3WUE7TL7GNXHF27B6Z54VMRCPTW2JH2OQRHH4U2EHPI6CCLMERGE'
         }
     }

--- a/business-logic/ledger-info.js
+++ b/business-logic/ledger-info.js
@@ -1,0 +1,9 @@
+import {retrieveLedgerInfo} from '@stellar-expert/ui-framework'
+
+//The API can resolve with an error object instead of a ledger, including on transport failures.
+export function parseLedgerResponse(data) {
+    if (!data || data.error || data.status >= 400 || typeof data.xdr !== 'string' || !data.xdr) {
+        throw new Error('Ledger data is unavailable.')
+    }
+    return retrieveLedgerInfo(data)
+}

--- a/business-logic/search.js
+++ b/business-logic/search.js
@@ -1,5 +1,6 @@
 import {StrKey} from '@stellar/stellar-sdk'
 import {parseStellarGenericId} from '@stellar-expert/ui-framework'
+import {normalizeSoranName} from './soran-name.js'
 
 const searchTypeMap = {
     account: 'account',
@@ -13,9 +14,10 @@ const searchTypeMap = {
 /**
  * Determine appropriate query type for the autolookup.
  * @param {string} query - Raw query.
- * @return {Array<('account'|'asset'|'contract'|'tx'|'ledger'|'text'|'federation'|'sorobandomains')>}
+ * @param {string} [network] - Explorer network.
+ * @return {Array<('account'|'asset'|'contract'|'tx'|'ledger'|'text'|'federation'|'sorobandomains'|'soran')>}
  */
-function detectSearchType(query) {
+function detectSearchType(query, network = 'public') {
     const res = []
     if (query) {
         if (['xlm', 'native', 'lumen'].includes(query.toLowerCase())) return ['asset']
@@ -29,6 +31,7 @@ function detectSearchType(query) {
         //federation address
         if (/^([a-z0-9-+]+)\.xlm$/i.test(query)) return ['sorobandomains']
         if (/^(.+)\*([^.]+\..+)$/.test(query)) return ['federation']
+        if (network === 'testnet' && normalizeSoranName(query)) return ['soran']
         //ledger, offer, tx/op generic id
         if (/^\d{1,19}$/.test(query)) {
             if (query.length <= 10) {

--- a/business-logic/soran-name.js
+++ b/business-logic/soran-name.js
@@ -1,0 +1,10 @@
+const namePattern = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+export function normalizeSoranName(value) {
+    if (typeof value !== 'string') return null
+    const trimmed = value.trim()
+    //Reject Unicode before lowercasing, including characters that fold to ASCII.
+    if (!/^[A-Za-z0-9.-]+$/.test(trimmed)) return null
+    const name = trimmed.toLowerCase()
+    return namePattern.test(name) ? name : null
+}

--- a/business-logic/soran-resolution.js
+++ b/business-logic/soran-resolution.js
@@ -1,0 +1,157 @@
+import {Account, Address, Contract, MuxedAccount, StrKey, TransactionBuilder, nativeToScVal, rpc} from '@stellar/stellar-sdk'
+import {normalizeSoranName} from './soran-name.js'
+
+export class SoranResolutionError extends Error {
+    constructor(message, code) {
+        super(message)
+        this.name = 'SoranResolutionError'
+        this.code = code
+    }
+}
+
+function invalidResult() {
+    throw new SoranResolutionError('Soran returned an unsupported or invalid destination.')
+}
+
+function readSymbol(value) {
+    if (value?.type !== 'scvSymbol') invalidResult()
+    return value.sym.toStringStrict()
+}
+
+function readVariant(value) {
+    if (value?.type !== 'scvVec' || !value.vec?.length) invalidResult()
+    const [tag, ...args] = value.vec
+    return [readSymbol(tag), args]
+}
+
+function readStruct(value, fields) {
+    if (value?.type !== 'scvMap' || value.map?.length !== fields.length) invalidResult()
+    const result = {}
+    for (let i = 0; i < fields.length; i++) {
+        //Soroban struct keys are symbols in canonical order; reject duplicates and unknown fields.
+        const entry = value.map[i]
+        if (readSymbol(entry.key) !== fields[i]) invalidResult()
+        result[fields[i]] = entry.val
+    }
+    return result
+}
+
+function readAddress(value, accountOnly = false) {
+    if (value?.type !== 'scvAddress') invalidResult()
+    const address = Address.fromScVal(value).toString()
+    if (!StrKey.isValidEd25519PublicKey(address) && (accountOnly || !StrKey.isValidContract(address))) invalidResult()
+    return address
+}
+
+function readId(value) {
+    if (value?.type !== 'scvU64' || typeof value.u64 !== 'bigint' || value.u64 < 0n || value.u64 > 18446744073709551615n) {
+        invalidResult()
+    }
+    return value.u64.toString()
+}
+
+function readMemo(value) {
+    const [type, args] = readVariant(value)
+    if (type === 'None' && !args.length) return null
+    if (args.length !== 1) invalidResult()
+    const [memo] = args
+    switch (type) {
+    case 'Id':
+        return {type: 'id', value: readId(memo)}
+    case 'Text':
+        if (memo.type !== 'scvString' || memo.str.length < 1 || memo.str.length > 28) invalidResult()
+        return {type: 'text', value: memo.str.toStringStrict()}
+    case 'Hash': {
+        if (memo.type !== 'scvBytes') invalidResult()
+        const bytes = memo.bytes.toBytes()
+        if (bytes.length !== 32) invalidResult()
+        return {type: 'hash', value: Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')}
+    }
+    default:
+        return invalidResult()
+    }
+}
+
+//Decode the destination ABI at the XDR boundary, preserving memos and full muxed IDs.
+export function decodeSoranDestination(value) {
+    try {
+        const [type, args] = readVariant(value)
+        if (args.length !== 1) invalidResult()
+        if (type === 'Direct') {
+            const payment = readStruct(args[0], ['address', 'memo'])
+            const address = readAddress(payment.address)
+            const memo = readMemo(payment.memo)
+            if (StrKey.isValidContract(address) && memo) invalidResult()
+            return {address, memo}
+        }
+        if (type === 'Muxed') {
+            const payment = readStruct(args[0], ['account', 'id'])
+            const account = readAddress(payment.account, true)
+            const id = readId(payment.id)
+            return {address: new MuxedAccount(new Account(account, '0'), id).accountId(), memo: null}
+        }
+        return invalidResult()
+    } catch (error) {
+        if (error instanceof SoranResolutionError) throw error
+        return invalidResult()
+    }
+}
+
+function contractError(code) {
+    if (code === 5) return new SoranResolutionError('Soran namespace not found.', code)
+    if (code === 7) return new SoranResolutionError('This Soran name is unregistered or expired.', code)
+    return new SoranResolutionError('Soran could not resolve this name. Please try again later.', code)
+}
+
+//Read only: no wallet, signature, transaction submission, Soran API, or Soran SDK.
+export async function resolveSoranName(query, network, settings) {
+    if (network !== 'testnet' || !settings?.soran) {
+        throw new SoranResolutionError('Soran name resolution is available on testnet only.')
+    }
+    const name = normalizeSoranName(query)
+    if (!name) throw new SoranResolutionError('Enter a Soran name with two valid labels, such as alice.nova.')
+
+    const {lookupId, registryId, rpcUrl} = settings.soran
+    const server = new rpc.Server(rpcUrl, {timeout: 15})
+    const contract = new Contract(lookupId)
+    async function read(method, args = []) {
+        const transaction = new TransactionBuilder(
+            new Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', '0'),
+            {fee: '100', networkPassphrase: settings.passphrase}
+        ).addOperation(contract.call(method, ...args)).setTimeout(30).build()
+        const result = await server.simulateTransaction(transaction, undefined, undefined, false)
+        if (rpc.Api.isSimulationRestore(result)) {
+            throw new SoranResolutionError('Soran contract state needs restoration. Please try again after it has been restored.')
+        }
+        if (rpc.Api.isSimulationError(result)) {
+            //Only classify the top-level contract error, never an error mentioned in a dependency's trace.
+            const match = /^HostError: Error\(Contract, #(\d+)\)/.exec(result.error)
+            throw contractError(method === 'resolve_destination' && match ? Number(match[1]) : undefined)
+        }
+        if (!rpc.Api.isSimulationSuccess(result) || !result.result?.retval) {
+            throw new SoranResolutionError('Soran resolution is unavailable. Please try again later.')
+        }
+        const value = result.result.retval
+        if (value.type === 'scvError' && value.error.type === 'sceContract') {
+            throw contractError(method === 'resolve_destination' ? value.error.contractCode : undefined)
+        }
+        return value
+    }
+
+    try {
+        const checks = await Promise.allSettled([read('registry'), read('version'), read('destination_version')])
+        for (const check of checks) {
+            if (check.status === 'rejected') throw check.reason
+        }
+        const [registry, version, destinationVersion] = checks.map(check => check.value)
+        if (readAddress(registry) !== registryId || version.type !== 'scvU32' || version.u32 !== 2 ||
+            destinationVersion.type !== 'scvU32' || destinationVersion.u32 !== 2) {
+            throw new SoranResolutionError('The Soran deployment is incompatible with this explorer.')
+        }
+        const destination = await read('resolve_destination', [nativeToScVal(name, {type: 'string'})])
+        return {name, ...decodeSoranDestination(destination)}
+    } catch (error) {
+        if (error instanceof SoranResolutionError) throw error
+        throw new SoranResolutionError('Soran resolution is unavailable. Please try again later.')
+    }
+}

--- a/docs/soran-resolution.md
+++ b/docs/soran-resolution.md
@@ -1,0 +1,99 @@
+# Soran testnet name resolution
+
+Searching for `alice.nova` on testnet resolves its current destination through Universal Lookup. The result shows the canonical name, complete destination, and required memo, with a link to the account or contract page. It remains on the search page so a memo is visible before opening account activity. M destinations link using the full M address.
+
+This implements forward search only. Account-wide reverse-name labels and payment submission are outside its scope. Public-network search and existing `.xlm` and federation resolution retain their behavior. Other Soran namespaces, such as `.orange`, use the same Lookup contract.
+
+## Contract reads
+
+The deployment is configured only under `networks.testnet.soran` in `app-settings.js`:
+
+| Setting | Value |
+| --- | --- |
+| RPC | `https://soroban-testnet.stellar.org` |
+| Lookup | `CDSORANQAJK35UV2HR63CMB6M5NYISHMUBTB6EQY2CZ3Y7HJDIOHRJWA` |
+| Registry anchor | `CCSORANDPQINYOYB5SVO45WJP2LBBYKC72HHUIRVXB4J6RUZKDAUW7G4` |
+| Network passphrase | `Test SDF Network ; September 2015` |
+
+Addresses were checked against the [current deployment reference](https://docs.soran.domains/reference/release-status) on 12 September 2026. Keep the Lookup and Registry from the same deployment when updating them after a migration or testnet reset.
+
+`resolveSoranName` uses `@stellar/stellar-sdk`, already a runtime dependency. Each lookup:
+
+1. Rejects networks other than testnet and normalizes the input to two lowercase ASCII labels, each 1–63 bytes. Unicode folding, URL parsing, extra dots, and leading/trailing hyphens are rejected.
+2. Checks `registry()`, `version() == 2`, and `destination_version() == 2`. These independent checks run concurrently.
+3. Simulates `resolve_destination(String(name))` only after those checks succeed. Lookup discovers the current namespace contracts and validates routing, ownership generation, expiry, and payment metadata in that invocation.
+4. Strictly decodes the returned XDR. Field symbols, enum arity, exact field sets, wire types, address types, and memo bounds are checked before rendering.
+
+Calls use unsigned transactions with a read-only simulation source. No wallet, secret, funding, submission, Soran SDK, or Soran HTTP API is involved. Requests have a 15-second timeout each. Results and failures are not cached. The returned destination is an observation; it does not lock subsequent ownership or routing changes.
+
+The anchor and ABI checks establish deployment compatibility, not an executable-code pin. They can observe different ledgers. Governance may upgrade contracts at their existing addresses. See [the on-chain API](https://docs.soran.domains/api/onchain-resolution).
+
+## Result and failure handling
+
+The resolver returns `{name, address, memo}`. `memo` is either `null` or `{type, value}`; types are `id`, `text`, and `hash`. Numeric IDs remain decimal strings, text retains its exact UTF-8 content, and hashes become 64 lowercase hex characters. A C contract must have no memo. A muxed result is reconstructed from its G account and exact u64 routing ID using Stellar SDK, preserving all 64 bits in the M address.
+
+Missing/expired names (Lookup error 7) receive a combined explanation because that code does not distinguish those states. Restoration, transport errors, unsupported ABIs, malformed results, and dependency failures remain errors. None is interpreted as a memo-free account or triggers a legacy-address fallback.
+
+Only an explicit namespace-missing error (5) from `resolve_destination` falls back to normal account/asset text search, because a dotted string can be an asset code. Errors in capability checks cannot trigger that fallback. Pending search resolutions are discarded after a query change, network switch, or unmount.
+
+## Raw contract storage
+
+Raw entries can be inspected using Stellar RPC `getLedgerEntries`, without a Soran SDK. They are deliberately not the source of validated search answers: separate reads can cross generations, and an omitted persistent entry may be archived rather than absent. Reading only the forward address loses required memos and muxed IDs. A reliable standalone reader would also need to track implementation hashes, contract anchors, routing, ownership expiry, generations, and archival semantics.
+
+The [storage reference](https://docs.soran.domains/reference/contract-storage) describes these keys for the current implementation. Before decoding raw state after an upgrade, compare contract executable hashes with the [deployment manifest](https://raw.githubusercontent.com/SoranDomains/docs/main/reference/deployments/testnet.json).
+
+For `label.namespace`, let `H` be SHA-256 and `zero32` be 32 zero bytes:
+
+```text
+namespaceNode = H(zero32 || H(ASCII(namespace)))
+nameNode      = H(namespaceNode || H(ASCII(label)))
+```
+
+Nodes are 32-byte values, not their printable hex strings. Persistent keys use `LedgerKey::ContractData` with the contract address, persistent durability, and the following ScVal vector:
+
+| Contract | Key vector | Value |
+| --- | --- | --- |
+| Registry | `[Symbol("Node"), Bytes(namespaceNode)]` | Namespace record: owner, owner epoch, current resolver, provenance statuses |
+| Registry | `[Symbol("Registrar"), Bytes(namespaceNode)]` | Attested Registrar address |
+| Registry | `[Symbol("Resolver"), Bytes(namespaceNode)]` | Attested Resolver address; distinct from the current resolver pointer |
+| Registrar | `[Symbol("Name"), Bytes(nameNode)]` | `{holder: Address, address: Address, expires_at: u64, generation: u64}` |
+| Resolver | `[Symbol("Addr"), Bytes(nameNode)]` | `{addr: Address, generation: u64}` |
+| Resolver | `[Symbol("Text"), Bytes(nameNode), Symbol("payment")]` | `{value: String, generation: u64}` |
+| Resolver | `[Symbol("PaymentConfigured"), Bytes(nameNode), U64(generation)]` | `true` for a configured ownership generation |
+
+Structs are ScVal maps with sorted symbol keys. Enum tags and the reserved `payment` key are symbols, not strings. Configurations live inside the contract instance's storage map under `[Symbol("Config")]`; they are not separate persistent `Config` entries. The instance is fetched using `new Contract(id).getFootprint()`.
+
+There is no standalone `Payment` entry. Complete instructions are stored in `TextRec.value`:
+
+| Destination | Stored string |
+| --- | --- |
+| G/C without memo | `1\|ADDRESS\|none\|` |
+| G with ID memo | `1\|G_ACCOUNT\|id\|DECIMAL_U64` |
+| G with text memo | `1\|G_ACCOUNT\|text\|UTF8_TEXT` |
+| G with hash memo | `1\|G_ACCOUNT\|hash\|LOWERCASE_HEX_32_BYTES` |
+| Muxed destination | `2\|G_ACCOUNT\|muxed\|DECIMAL_U64` |
+
+Only the first three pipes delimit fields; memo text can contain pipes. IDs span `0`–`18446744073709551615`. Text occupies 1–28 UTF-8 bytes; hash payloads encode exactly 32 bytes. The stored M instruction contains its base G account and routing ID, while `AddrRec` contains only the G account.
+
+The address record, payment text, and configured marker must agree with the Registrar's active generation. A finite `expires_at` expires strictly after that Unix timestamp; zero means no ownership deadline. TTL uses ledger numbers and is independent of ownership expiry. Missing configured payment metadata cannot be interpreted as “no memo.”
+
+A raw inspection of `alice.nova` on 12 September 2026 returned generation `0`, an explicit address and a `true` configured marker. Its payment string was:
+
+```text
+1|GBES5UHJYI445RV4XBGWHZOMBW4RYXBHOX47ZNZAJZAH2WP42ZEP2DYQ|text|hello
+```
+
+This snapshot illustrates the storage format; live records can change.
+
+## Validation
+
+Use Node 22.12 or newer, as required by Stellar SDK 17, and install with `pnpm i`.
+
+```sh
+pnpm test
+pnpm build
+```
+
+Tests include the published [destination XDR fixtures](https://docs.soran.domains/reference/lookup-decoding), RPC failure and compatibility cases, full u64 boundaries, UTF-8 handling, existing search detection, rendered account/contract links, memo preservation, and late-response/network-switch behavior. Fixtures are checked in with their source so tests do not access a network. The UI tests use the project's Babel configuration and React 17 test renderer.
+
+For a manual smoke test, start `pnpm dev-server` and search testnet for `alice.nova`, `nikcle.nova`, `robert.nova`, `echo.nova`, `mux.nova`, and `cyclops.nova`. Check text/ID/hash memos, the complete M link, and the C contract link. Also try `.orange`, an unregistered `.nova` name, switching to public during resolution, and existing `.xlm`/federation searches. Current examples are documented [here](https://docs.soran.domains/live-examples).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Block explorer with analytics platform for Stellar Network that features granular historical statistics, detailed assets dashboard, and advanced payment locator.",
   "main": "app.js",
   "scripts": {
+    "test": "node --test test/*.test.mjs",
     "build": "webpack --mode=production --config ./webpack-config.js",
     "dev-server": "webpack serve --mode development --config ./webpack-config.js",
     "build-api-docs": "node -v"
@@ -39,9 +40,11 @@
     "throttle-debounce": "^5.0.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
     "@stellar-expert/eslint-config-js": "^1.1.0",
     "@stellar-expert/eslint-config-react": "^1.1.0",
-    "@stellar-expert/webpack-template": "1.5.1"
+    "@stellar-expert/webpack-template": "1.5.1",
+    "react-test-renderer": "17.0.2"
   },
   "overrides": {
     "@stellar/stellar-sdk": "17.0.1"

--- a/test/fixtures/ledger.json
+++ b/test/fixtures/ledger.json
@@ -1,0 +1,11 @@
+{
+  "source": "https://api.stellar.expert/explorer/testnet/ledger/last",
+  "sequence": 4634265,
+  "ts": 1789194912,
+  "protocol": 28,
+  "xdr": "AAAAHAujYwmA8XJ4LN3wBhA6IVs+jwRqDT0JgtP67Qsdm7/OOdrCAxu5x1hEFThZUwDJA00Wvv2f2BPofBkJtMZETVUAAAAAaqTyoAAAAAAAAAABAAAAAKgkzRi8nXUGTSmaW1uspDvDqi8yaTgVPYwvm7XLbfAzAAAAQIdbkQAX3YQbwO+MeEDOY8VK/ngZZ85HHUSqOXDKgNCIBB3yy8bsvrb4dPo2J96BtrLKkNsbwIhz+SMbZcTVQgiRQKB9UdGIzjsxUiFJU6BXM/u7rKIgzcQM+4UYao/uoBGn2Jh6XFJ0QL2GC1Fu+/mECSfdWIU12ua9BrvqwvRFAEa2mQ3gtrOnZAAAAAAE8OMELx4AAAAAAAAAAAAMjBgAAABkAExLQAAAAMhlcxs77H8B/C3/2rDpGFzrbLTY9KOamkxIi2qcQ73AzxeM0E43BdgN6L2Je4dNnN/GJDe8NzZiZXuZaGbjjVEF8jw8wfkg4PV7iVYrGtue4pcVu6JsTs5BgDl57NqMx7EAfbRzTOUFrgCd0a1NWFFVuKGt8FhQJ3iV3juXCzeRGwAAAAA=",
+  "successful_operations": 21,
+  "failed_operations": 2,
+  "successful_transactions": 21,
+  "failed_transactions": 2
+}

--- a/test/fixtures/soran-destinations.json
+++ b/test/fixtures/soran-destinations.json
@@ -1,0 +1,330 @@
+{
+  "source": "https://raw.githubusercontent.com/SoranDomains/docs/main/reference/vectors/lookup-returns-v1.json",
+  "retrieved": "2026-09-12",
+  "scope": "PaymentDestination ABI 2 conformance vectors; synthetic, not live records",
+  "valid": [
+    {
+      "id": "direct-g-none",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQ==",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "None"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-g-id-zero",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAACSWQAAAAAAAUAAAAAAAAAAA==",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "Id",
+            {
+              "$bigint": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-g-id-77",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAACSWQAAAAAAAUAAAAAAAAATQ==",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "Id",
+            {
+              "$bigint": "77"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-g-id-max",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAACSWQAAAAAAAX//////////w==",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "Id",
+            {
+              "$bigint": "18446744073709551615"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-g-text",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAEVGV4dAAAAA4AAAAKaW52b2ljZS03NwAA",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "Text",
+            "invoice-77"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-g-text-utf8-boundary",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAEVGV4dAAAAA4AAAAc8J+YgPCfmIDwn5iA8J+YgPCfmIDwn5iA8J+YgA==",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "Text",
+            "\ud83d\ude00\ud83d\ude00\ud83d\ude00\ud83d\ude00\ud83d\ude00\ud83d\ude00\ud83d\ude00"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-g-text-leading-bom",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAEVGV4dAAAAA4AAAAH77u/bWVtbwA=",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "Text",
+            "\ufeffmemo"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-g-hash",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAESGFzaAAAAA0AAAAgAAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "memo": [
+            "Hash",
+            {
+              "$bytes": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "direct-c-none",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAeTogbACVb7Sujx9sTA+Z1uESOygZh8SGNCzvHzpGhx4AAAADwAAAARtZW1vAAAAEAAAAAEAAAABAAAADwAAAAROb25l",
+      "expectedNative": [
+        "Direct",
+        {
+          "address": "CDSORANQAJK35UV2HR63CMB6M5NYISHMUBTB6EQY2CZ3Y7HJDIOHRJWA",
+          "memo": [
+            "None"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "muxed-0",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAVNdXhlZAAAAAAAABEAAAABAAAAAgAAAA8AAAAHYWNjb3VudAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAACaWQAAAAAAAUAAAAAAAAAAA==",
+      "expectedNative": [
+        "Muxed",
+        {
+          "account": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "id": {
+            "$bigint": "0"
+          }
+        }
+      ]
+    },
+    {
+      "id": "muxed-420",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAVNdXhlZAAAAAAAABEAAAABAAAAAgAAAA8AAAAHYWNjb3VudAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAACaWQAAAAAAAUAAAAAAAABpA==",
+      "expectedNative": [
+        "Muxed",
+        {
+          "account": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "id": {
+            "$bigint": "420"
+          }
+        }
+      ]
+    },
+    {
+      "id": "muxed-18446744073709551615",
+      "returnType": "PaymentDestination",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAVNdXhlZAAAAAAAABEAAAABAAAAAgAAAA8AAAAHYWNjb3VudAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAACaWQAAAAAAAX//////////w==",
+      "expectedNative": [
+        "Muxed",
+        {
+          "account": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "id": {
+            "$bigint": "18446744073709551615"
+          }
+        }
+      ]
+    }
+  ],
+  "invalid": [
+    {
+      "id": "missing-destination",
+      "returnType": "PaymentDestination",
+      "reason": "Void is not a payment instruction",
+      "xdrBase64": "AAAAAQ=="
+    },
+    {
+      "id": "unknown-destination",
+      "returnType": "PaymentDestination",
+      "reason": "Unknown enum tag",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAVPdGhlcgAAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQ=="
+    },
+    {
+      "id": "string-tag",
+      "returnType": "PaymentDestination",
+      "reason": "Variant tag must be an XDR Symbol",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADgAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQ=="
+    },
+    {
+      "id": "missing-payload",
+      "returnType": "PaymentDestination",
+      "reason": "Direct needs one payload",
+      "xdrBase64": "AAAAEAAAAAEAAAABAAAADwAAAAZEaXJlY3QAAA=="
+    },
+    {
+      "id": "extra-payload",
+      "returnType": "PaymentDestination",
+      "reason": "Direct cannot have extra values",
+      "xdrBase64": "AAAAEAAAAAEAAAADAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQAAAAMAAAAA"
+    },
+    {
+      "id": "void-memo",
+      "returnType": "PaymentDestination",
+      "reason": "Void is not explicit Memo::None",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAAAE="
+    },
+    {
+      "id": "none-with-value",
+      "returnType": "PaymentDestination",
+      "reason": "None cannot carry a value",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAETm9uZQAAAAMAAAAA"
+    },
+    {
+      "id": "id-u32",
+      "returnType": "PaymentDestination",
+      "reason": "Id must use u64 even for small values",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAACSWQAAAAAAAMAAABN"
+    },
+    {
+      "id": "id-negative",
+      "returnType": "PaymentDestination",
+      "reason": "Negative IDs are invalid",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAACSWQAAAAAAAb//////////w=="
+    },
+    {
+      "id": "text-empty",
+      "returnType": "PaymentDestination",
+      "reason": "Text must contain at least one byte",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAEVGV4dAAAAA4AAAAA"
+    },
+    {
+      "id": "text-too-long",
+      "returnType": "PaymentDestination",
+      "reason": "Text exceeds 28 UTF-8 bytes",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAEVGV4dAAAAA4AAAAg8J+YgPCfmIDwn5iA8J+YgPCfmIDwn5iA8J+YgPCfmIA="
+    },
+    {
+      "id": "text-invalid-utf8",
+      "returnType": "PaymentDestination",
+      "reason": "Text must be valid UTF-8",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAEVGV4dAAAAA4AAAAB/wAAAA=="
+    },
+    {
+      "id": "hash-too-short",
+      "returnType": "PaymentDestination",
+      "reason": "Hash must contain 32 bytes",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAgAAAA8AAAAESGFzaAAAAA0AAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    },
+    {
+      "id": "contract-with-memo",
+      "returnType": "PaymentDestination",
+      "reason": "C destinations support None only",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAeTogbACVb7Sujx9sTA+Z1uESOygZh8SGNCzvHzpGhx4AAAADwAAAARtZW1vAAAAEAAAAAEAAAACAAAADwAAAAJJZAAAAAAABQAAAAAAAABN"
+    },
+    {
+      "id": "string-address",
+      "returnType": "PaymentDestination",
+      "reason": "Address must use XDR Address, not an address-shaped string",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAAOAAAAOEdBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBV0hGAAAADwAAAARtZW1vAAAAEAAAAAEAAAABAAAADwAAAAROb25l"
+    },
+    {
+      "id": "extra-field",
+      "returnType": "PaymentDestination",
+      "reason": "Direct requires exactly address and memo",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAwAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAFZXh0cmEAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQ=="
+    },
+    {
+      "id": "duplicate-field",
+      "returnType": "PaymentDestination",
+      "reason": "Duplicate field names are invalid",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAwAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQ=="
+    },
+    {
+      "id": "unordered-fields",
+      "returnType": "PaymentDestination",
+      "reason": "Field-symbol map must use canonical order",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    },
+    {
+      "id": "string-field-key",
+      "returnType": "PaymentDestination",
+      "reason": "Field key must be an XDR Symbol",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA4AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQ=="
+    },
+    {
+      "id": "muxed-contract-base",
+      "returnType": "PaymentDestination",
+      "reason": "Muxed base must be a G account",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAVNdXhlZAAAAAAAABEAAAABAAAAAgAAAA8AAAAHYWNjb3VudAAAAAASAAAAAeTogbACVb7Sujx9sTA+Z1uESOygZh8SGNCzvHzpGhx4AAAADwAAAAJpZAAAAAAABQAAAAAAAAGk"
+    },
+    {
+      "id": "muxed-u32-id",
+      "returnType": "PaymentDestination",
+      "reason": "Routing ID must use u64",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAVNdXhlZAAAAAAAABEAAAABAAAAAgAAAA8AAAAHYWNjb3VudAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAACaWQAAAAAAAMAAAGk"
+    },
+    {
+      "id": "muxed-separate-memo",
+      "returnType": "PaymentDestination",
+      "reason": "Muxed has no separate memo field",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAVNdXhlZAAAAAAAABEAAAABAAAAAwAAAA8AAAAHYWNjb3VudAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAACaWQAAAAAAAUAAAAAAAABpAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAETm9uZQ=="
+    },
+    {
+      "id": "truncated-xdr",
+      "returnType": "PaymentDestination",
+      "reason": "Truncated XDR is invalid",
+      "xdrBase64": "AAAAEAAAAAEAAAACAAAADwAAAAZEaXJlY3QAAAAAABEAAAABAAAAAgAAAA8AAAAHYWRkcmVzcwAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAEbWVtbwAAABAAAAABAAAAAQAAAA8AAAAE"
+    }
+  ]
+}

--- a/test/ledger-activity.test.mjs
+++ b/test/ledger-activity.test.mjs
@@ -1,0 +1,164 @@
+/*eslint require-await: off*/
+//Async act callbacks flush the component's loading promises and effects.
+import assert from 'node:assert/strict'
+import {readFileSync} from 'node:fs'
+import {test} from 'node:test'
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import {loadUiModule} from './load-ui-module.mjs'
+
+const {act, create} = TestRenderer
+const fixture = JSON.parse(readFileSync(new URL('./fixtures/ledger.json', import.meta.url)))
+const {retrieveLedgerInfo} = loadUiModule('../node_modules/@stellar-expert/ui-framework/ledger/ledger-info-parser.js')
+const {parseLedgerResponse} = loadUiModule('../business-logic/ledger-info.js', {
+    '@stellar-expert/ui-framework': {retrieveLedgerInfo}
+})
+
+test('valid API ledger data is decoded with the actual SDK parser', () => {
+    const ledger = parseLedgerResponse(fixture)
+    assert.equal(ledger.sequence, fixture.sequence)
+    assert.equal(ledger.operations, fixture.successful_operations)
+    assert.equal(ledger.baseFee, 100)
+    assert.equal(ledger.baseReserve, 5000000)
+})
+
+test('API errors and missing headers never reach the XDR decoder', () => {
+    const parser = loadUiModule('../business-logic/ledger-info.js', {
+        '@stellar-expert/ui-framework': {retrieveLedgerInfo: () => assert.fail('Invalid data reached XDR decoding')}
+    })
+    for (const data of [undefined, null, {}, {error: 'Failed to fetch', status: 500}, {status: 403},
+        {...fixture, error: 'Unavailable'}, {...fixture, xdr: ''}, {...fixture, xdr: 123}]) {
+        assert.throws(() => parser.parseLedgerResponse(data), /unavailable/)
+    }
+})
+
+function setup(t, {loadLast = () => Promise.resolve(fixture), loadLedger = () => Promise.resolve(fixture)} = {}) {
+    const listeners = new Set()
+    const stream = {
+        getLast: t.mock.fn(loadLast),
+        on: listener => listeners.add(listener),
+        off: listener => listeners.delete(listener)
+    }
+    const View = loadUiModule('../views/explorer/ledger/ledger-activity-view.js', {
+        '@stellar-expert/ui-framework': {
+            ledgerStream: stream,
+            useStellarNetwork: () => 'testnet',
+            Amount: ({amount}) => React.createElement('span', null, String(amount)),
+            UpdateHighlighter: ({children}) => children
+        },
+        '../../../models/api': {apiCall: loadLedger},
+        '../../../business-logic/path': {resolvePath: path => `/explorer/testnet/${path}`},
+        '../../../business-logic/ledger-info': {parseLedgerResponse},
+        '../widget/embed-widget-trigger': () => null
+    }).default
+    let renderer
+    t.after(() => act(() => renderer?.unmount()))
+    return {
+        stream, listeners,
+        get renderer() {
+            return renderer
+        },
+        async mount() {
+            await act(async () => {
+                renderer = create(React.createElement(View))
+            })
+        },
+        async emit(sequence) {
+            await act(async () => {
+                await Promise.all(Array.from(listeners, listener => listener(sequence)))
+            })
+        }
+    }
+}
+
+for (const [description, data] of [
+    ['an API error object', {error: 'Failed to fetch', status: 500}],
+    ['a missing header', {sequence: 1}],
+    ['malformed XDR', {...fixture, xdr: 'not-an-xdr-header'}]
+]) {
+    test(`initial loading handles ${description} without an unhandled rejection`, async t => {
+        const ui = setup(t, {loadLast: () => Promise.resolve(data)})
+        await ui.mount()
+        assert.equal(ui.renderer.root.findAllByProps({role: 'alert'}).length, 1)
+        assert.equal(ui.renderer.root.findByType('button').children.join(''), 'Retry')
+        assert.equal(ui.listeners.size, 1)
+    })
+}
+
+test('a rejected initial request can be retried successfully', async t => {
+    let attempts = 0
+    const ui = setup(t, {loadLast: () => ++attempts === 1 ? Promise.reject(new Error('Connection failed')) : Promise.resolve(fixture)})
+    await ui.mount()
+    await act(async () => ui.renderer.root.findByType('button').props.onClick())
+    assert.equal(ui.renderer.root.findAllByProps({role: 'alert'}).length, 0)
+    assert.equal(ui.stream.getLast.mock.callCount(), 2)
+    assert.equal(ui.listeners.size, 1)
+    assert(ui.renderer.root.findAllByType('a').some(link => link.props.href.endsWith(`/ledger/${fixture.sequence}`)))
+})
+
+test('a valid stream update recovers from an initial API failure', async t => {
+    const ui = setup(t, {loadLast: () => Promise.resolve({error: 'Unavailable'})})
+    await ui.mount()
+    await ui.emit(fixture.sequence)
+    assert.equal(ui.renderer.root.findAllByProps({role: 'alert'}).length, 0)
+})
+
+test('a rejected update is handled and a later update recovers', async t => {
+    let updates = 0
+    const ui = setup(t, {loadLedger: () => ++updates === 1 ? Promise.reject(new Error('Timeout')) :
+        Promise.resolve({...fixture, sequence: fixture.sequence + 1, ts: fixture.ts + 5})})
+    await ui.mount()
+    await ui.emit(fixture.sequence + 1)
+    assert.equal(ui.renderer.root.findAllByProps({role: 'alert'}).length, 1)
+    await ui.emit(fixture.sequence + 1)
+    assert.equal(ui.renderer.root.findAllByProps({role: 'alert'}).length, 0)
+})
+
+test('a late initial response does not overwrite a newer streamed ledger', async t => {
+    let finish
+    const newer = {...fixture, sequence: fixture.sequence + 1, ts: fixture.ts + 5}
+    const ui = setup(t, {loadLast: () => new Promise(resolve => {
+        finish = resolve
+    }), loadLedger: () => Promise.resolve(newer)})
+    await ui.mount()
+    await ui.emit(newer.sequence)
+    await act(async () => finish(fixture))
+    assert(ui.renderer.root.findAllByType('a').some(link => link.props.href.endsWith(`/ledger/${newer.sequence}`)))
+})
+
+test('unmount during loading removes the listener and ignores the late result', async t => {
+    let finish
+    const ui = setup(t, {loadLast: () => new Promise(resolve => {
+        finish = resolve
+    })})
+    await ui.mount()
+    act(() => ui.renderer.unmount())
+    assert.equal(ui.listeners.size, 0)
+    await act(async () => finish(fixture))
+    assert.equal(ui.listeners.size, 0)
+})
+
+for (const response of [
+    {loaded: true, data: null, error: 'Unavailable'},
+    {loaded: true, data: {sequence: 1}},
+    {loaded: true, data: {...fixture, xdr: 'invalid'}}
+]) {
+    test(`ledger details handle invalid response ${JSON.stringify(response).slice(0, 65)}`, async t => {
+        const View = loadUiModule('../views/explorer/ledger/ledger-view.js', {
+            '@stellar-expert/ui-framework': {useExplorerApi: () => response, usePageMetadata: () => {}},
+            '../../../app-settings': {activeNetwork: 'testnet'},
+            '../../../business-logic/path': {},
+            '../../../business-logic/ledger-info': {parseLedgerResponse},
+            '../../components/error-notification-block': ({children}) => React.createElement('div', {role: 'alert'}, children),
+            '../../components/crawler-screen': () => null,
+            '../horizon-tracer/tracer-icon-view': () => null,
+            './ledger-transactions-view': () => null
+        }).default
+        let renderer
+        t.after(() => act(() => renderer?.unmount()))
+        await act(async () => {
+            renderer = create(React.createElement(View, {match: {params: {sequence: '1'}}}))
+        })
+        assert.match(renderer.root.findByProps({role: 'alert'}).children.join(''), /Failed to load ledger 1/)
+    })
+}

--- a/test/load-ui-module.mjs
+++ b/test/load-ui-module.mjs
@@ -1,0 +1,15 @@
+import {readFileSync} from 'node:fs'
+import {createRequire} from 'node:module'
+import {fileURLToPath} from 'node:url'
+import {transformSync} from '@babel/core'
+
+//Use the application's Babel configuration for JSX; replace browser services at module boundaries.
+export function loadUiModule(relativePath, replacements = {}) {
+    const filename = fileURLToPath(new URL(relativePath, import.meta.url))
+    const require = createRequire(filename)
+    const module = {exports: {}}
+    const {code} = transformSync(readFileSync(filename, 'utf8'), {filename})
+    const evaluate = new Function('require', 'module', 'exports', code)
+    evaluate(specifier => Object.hasOwn(replacements, specifier) ? replacements[specifier] : require(specifier), module, module.exports)
+    return module.exports
+}

--- a/test/soran-resolution.test.mjs
+++ b/test/soran-resolution.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict'
+import {readFileSync} from 'node:fs'
+import {test} from 'node:test'
+import {Address, MuxedAccount, Networks, rpc, xdr} from '@stellar/stellar-sdk'
+import {normalizeSoranName} from '../business-logic/soran-name.js'
+import {decodeSoranDestination, resolveSoranName, SoranResolutionError} from '../business-logic/soran-resolution.js'
+
+const fixtures = JSON.parse(readFileSync(new URL('./fixtures/soran-destinations.json', import.meta.url)))
+const settings = {
+    passphrase: Networks.TESTNET,
+    soran: {
+        rpcUrl: 'https://soroban-testnet.stellar.org',
+        lookupId: 'CDSORANQAJK35UV2HR63CMB6M5NYISHMUBTB6EQY2CZ3Y7HJDIOHRJWA',
+        registryId: 'CCSORANDPQINYOYB5SVO45WJP2LBBYKC72HHUIRVXB4J6RUZKDAUW7G4'
+    }
+}
+const sample = xdr.ScVal.fromXdr(fixtures.valid.find(fixture => fixture.id === 'direct-g-text').xdrBase64, 'base64')
+
+test('normalize names without Unicode folding or changing label boundaries', () => {
+    for (const [input, expected] of [
+        [' Alice.Nova ', 'alice.nova'], ['A-1.NOVA', 'a-1.nova'], ['a.b', 'a.b'],
+        ['a'.repeat(63) + '.' + 'b'.repeat(63), 'a'.repeat(63) + '.' + 'b'.repeat(63)]
+    ]) assert.equal(normalizeSoranName(input), expected)
+    for (const invalid of [
+        '', null, 42, 'alice', '.nova', 'alice.', '-alice.nova', 'alice-.nova', 'alice.-nova',
+        'alice.nova-', 'alice..nova', 'alice.sub.nova', 'al ice.nova', 'alice_nova', 'alice_.nova',
+        'alice.nova\nextra', 'alice.nova.', 'https://alice.nova', 'alice.nova/path', 'álîce.nova',
+        'Kate.nova', 'Ａlice.nova', 'alice。nova', 'a'.repeat(64) + '.nova', 'alice.' + 'a'.repeat(64)
+    ]) assert.equal(normalizeSoranName(invalid), null, String(invalid))
+})
+
+for (const fixture of fixtures.valid) {
+    test(`decode published XDR: ${fixture.id}`, () => {
+        const actual = decodeSoranDestination(xdr.ScVal.fromXdr(fixture.xdrBase64, 'base64'))
+        const [type, expected] = fixture.expectedNative
+        if (type === 'Muxed') {
+            const muxed = MuxedAccount.fromAddress(actual.address, '0')
+            assert.equal(muxed.baseAccount().accountId(), expected.account)
+            assert.equal(muxed.id(), expected.id.$bigint)
+            assert.equal(actual.memo, null)
+        } else {
+            assert.equal(actual.address, expected.address)
+            const [memoType, memoValue] = expected.memo
+            assert.deepEqual(actual.memo, memoType === 'None' ? null : {
+                type: memoType.toLowerCase(),
+                value: memoValue?.$bigint ?? memoValue?.$bytes ?? memoValue
+            })
+        }
+    })
+}
+
+for (const fixture of fixtures.invalid) {
+    test(`reject published XDR: ${fixture.id}`, () => {
+        assert.throws(() => decodeSoranDestination(xdr.ScVal.fromXdr(fixture.xdrBase64, 'base64')))
+    })
+}
+
+function success(retval) {
+    return {transactionData: {}, result: {retval}, latestLedger: 123}
+}
+
+function mockRpc(t, overrides = {}) {
+    const calls = []
+    t.mock.method(rpc.Server.prototype, 'simulateTransaction', (transaction, resources, authMode, upgradedAuth) => {
+        const operation = transaction.operations[0]
+        assert.equal(transaction.operations.length, 1)
+        assert.equal(transaction.signatures.length, 0)
+        assert.equal(transaction.networkPassphrase, Networks.TESTNET)
+        assert.equal(upgradedAuth, false)
+        const invocation = operation.func.invokeContract
+        assert.equal(Address.fromScAddress(invocation.contractAddress).toString(), settings.soran.lookupId)
+        const method = invocation.functionName.toStringStrict()
+        calls.push({method, args: invocation.args})
+        if (method in overrides) return overrides[method](invocation.args)
+        if (method === 'registry') return success(new Address(settings.soran.registryId).toScVal())
+        if (['version', 'destination_version'].includes(method)) return success(xdr.ScVal.scvU32(2))
+        assert.equal(method, 'resolve_destination')
+        return success(sample)
+    })
+    t.mock.method(rpc.Server.prototype, 'sendTransaction', () => assert.fail('Reads must never submit transactions'))
+    return calls
+}
+
+test('resolve a canonical name only after validating deployment and ABI', async t => {
+    const calls = mockRpc(t)
+    const result = await resolveSoranName(' Alice.Nova ', 'testnet', settings)
+    assert.deepEqual(result, {name: 'alice.nova', ...decodeSoranDestination(sample)})
+    assert.deepEqual(calls.map(call => call.method), ['registry', 'version', 'destination_version', 'resolve_destination'])
+    assert.equal(calls[3].args.length, 1)
+    assert.equal(calls[3].args[0].type, 'scvString')
+    assert.equal(calls[3].args[0].str.toStringStrict(), 'alice.nova')
+})
+
+test('public/unknown networks, missing configuration, and invalid input make no RPC calls', async t => {
+    const calls = mockRpc(t)
+    for (const network of ['public', 'futurenet', undefined]) {
+        await assert.rejects(resolveSoranName('alice.nova', network, settings), /testnet only/)
+    }
+    await assert.rejects(resolveSoranName('alice.nova', 'testnet', {}), /testnet only/)
+    await assert.rejects(resolveSoranName('alice.sub.nova', 'testnet', settings), /two valid labels/)
+    assert.equal(calls.length, 0)
+})
+
+for (const [method, value] of [
+    ['registry', new Address(settings.soran.lookupId).toScVal()],
+    ['registry', xdr.ScVal.scvString(settings.soran.registryId)],
+    ['version', xdr.ScVal.scvU32(3)],
+    ['version', xdr.ScVal.scvI32(2)],
+    ['destination_version', xdr.ScVal.scvU32(1)]
+]) {
+    test(`reject incompatible ${method} (${value.type}) before resolving`, async t => {
+        const calls = mockRpc(t, {[method]: () => success(value)})
+        await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), SoranResolutionError)
+        assert.equal(calls.some(call => call.method === 'resolve_destination'), false)
+    })
+}
+
+test('reject restoration even when the simulation also reports success', async t => {
+    mockRpc(t, {resolve_destination: () => ({...success(sample), restorePreamble: {transactionData: {}}})})
+    await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), /needs restoration/)
+})
+
+test('capability failures cannot be mistaken for an absent namespace', async t => {
+    mockRpc(t, {registry: () => ({error: 'HostError: Error(Contract, #5)'})})
+    await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), error => error.code === undefined)
+})
+
+for (const code of [5, 7, 9, 10, 11, 12, 22, 999]) {
+    test(`preserve contract error ${code} without address or legacy fallback`, async t => {
+        const calls = mockRpc(t, {resolve_destination: () => ({error: `HostError: Error(Contract, #${code})\nEvent log ...`})})
+        await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), error => error.code === code)
+        assert.equal(calls.length, 4)
+    })
+}
+
+test('do not misclassify contract errors inside a host failure trace', async t => {
+    mockRpc(t, {resolve_destination: () => ({error: 'HostError: Error(Budget, ExceededLimit)\nError(Contract, #5)'})})
+    await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), error => error.code === undefined)
+})
+
+test('preserve typed contract errors returned as ScVal', async t => {
+    mockRpc(t, {resolve_destination: () => success(xdr.ScVal.scvError(xdr.ScError.sceContract(7)))})
+    await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), error => error.code === 7)
+})
+
+for (const [label, result] of [['empty response', {}], ['missing return value', {transactionData: {}}]]) {
+    test(`reject ${label}`, async t => {
+        mockRpc(t, {resolve_destination: () => result})
+        await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), /unavailable/)
+    })
+}
+
+test('report transport failures as unavailable and allow a subsequent retry', async t => {
+    let failed = false
+    const calls = mockRpc(t, {resolve_destination: () => {
+        if (!failed) {
+            failed = true
+            throw new Error('network timeout')
+        }
+        return success(sample)
+    }})
+    await assert.rejects(resolveSoranName('alice.nova', 'testnet', settings), /unavailable/)
+    assert.equal((await resolveSoranName('alice.nova', 'testnet', settings)).name, 'alice.nova')
+    assert.equal(calls.length, 8)
+})

--- a/test/soran-search.test.mjs
+++ b/test/soran-search.test.mjs
@@ -1,0 +1,185 @@
+/*eslint require-await: off*/
+//Async act callbacks let React flush pending effects and resolution promises.
+import assert from 'node:assert/strict'
+import {beforeEach, test} from 'node:test'
+import React, {useEffect} from 'react'
+import TestRenderer from 'react-test-renderer'
+import * as stellarSdk from '@stellar/stellar-sdk'
+import {SoranResolutionError} from '../business-logic/soran-resolution.js'
+import {loadUiModule} from './load-ui-module.mjs'
+
+const {act, create} = TestRenderer
+const genericIds = loadUiModule('../node_modules/@stellar-expert/ui-framework/stellar/ledger-generic-id.js')
+const stateHooks = loadUiModule('../node_modules/@stellar-expert/ui-framework/state/state-hooks.js')
+const {detectSearchType} = loadUiModule('../business-logic/search.js', {'@stellar-expert/ui-framework': genericIds})
+const G = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+const C = 'CDSORANQAJK35UV2HR63CMB6M5NYISHMUBTB6EQY2CZ3Y7HJDIOHRJWA'
+const M = 'MDHHA2WBSH4ZKIAWALPY4KVOC57ZUT6W6HWS3JBUQ4KFJRT6US4MWAAAAAAAAAAAFKV2W'
+
+beforeEach(t => {
+    t.mock.method(globalThis, 'fetch', () => assert.fail('Unit tests must not access the network'))
+})
+
+test('detect Soran only on testnet and retain existing search types', () => {
+    for (const name of ['alice.nova', ' Alice.NOVA ', 'mux.orange', 'user.future']) {
+        assert.deepEqual(detectSearchType(name, 'testnet'), ['soran'])
+        assert.deepEqual(detectSearchType(name, 'public'), ['account', 'asset'])
+        assert.deepEqual(detectSearchType(name), ['account', 'asset'])
+    }
+    for (const network of ['testnet', 'public']) {
+        for (const [query, expected] of [
+            ['alice.xlm', ['sorobandomains']], ['alice*example.org', ['federation']],
+            [G, ['account', 'asset']], [C, ['contract', 'asset']], [M, ['account']],
+            ['XLM', ['asset']], ['USD', ['account', 'asset']], ['a'.repeat(64), ['transaction']],
+            ['4651470', ['ledger', 'offer', 'account', 'asset']], ['alice.sub.nova', ['account', 'asset']]
+        ]) assert.deepEqual(detectSearchType(query, network), expected)
+    }
+})
+
+function setup(t, resolve, term = 'alice.nova') {
+    let network = 'testnet'
+    const resolutions = []
+    const standardSearches = []
+    const navigations = []
+    const navigation = {query: {term}, navigate: path => navigations.push(path)}
+    const framework = {...stateHooks, navigation, usePageMetadata: () => {}}
+    const appSettings = {get activeNetwork() {
+        return network
+    }, networks: {testnet: {}, public: {}}}
+    const path = {resolvePath: relative => `/explorer/${network}/${relative}`}
+    const SoranResult = loadUiModule('../views/explorer/search/soran-search-result-view.js', {'../../../business-logic/path': path}).default
+    const replacements = {
+        '@stellar/stellar-sdk': stellarSdk,
+        '@stellar-expert/ui-framework': framework,
+        '../../../app-settings': appSettings,
+        '../../../business-logic/search': {detectSearchType},
+        '../../../business-logic/path': path,
+        '../../../business-logic/soran-resolution': {
+            SoranResolutionError,
+            resolveSoranName: (...args) => {
+                resolutions.push(args)
+                return resolve(...args)
+            }
+        },
+        './soran-search-result-view': SoranResult,
+        '../../components/error-notification-block': ({children}) => React.createElement('div', {role: 'alert'}, children),
+        './search.scss': {}
+    }
+    for (const type of ['assets', 'account', 'ledger', 'operation', 'transaction', 'offer', 'contract']) {
+        replacements[`./${type}-search-results-view`] = function Result({term: query, onLoaded}) {
+            useEffect(() => {
+                standardSearches.push({type, query})
+                onLoaded(null)
+            }, [query, onLoaded])
+            return null
+        }
+    }
+    const View = loadUiModule('../views/explorer/search/search-results-view.js', replacements).default
+    let renderer
+    t.after(() => act(() => renderer?.unmount()))
+    t.mock.method(console, 'error', () => {})
+    return {
+        resolutions, standardSearches, navigations,
+        async show(nextTerm = term, nextNetwork = network) {
+            navigation.query.term = nextTerm
+            network = nextNetwork
+            await act(async () => {
+                if (renderer) renderer.update(React.createElement(View))
+                else renderer = create(React.createElement(View))
+            })
+        },
+        get renderer() {
+            return renderer
+        }
+    }
+}
+
+function renderedText(renderer) {
+    function flatten(node) {
+        if (typeof node === 'string') return node
+        if (Array.isArray(node)) return node.map(flatten).join('')
+        return node?.children ? flatten(node.children) : ''
+    }
+    return flatten(renderer.toJSON())
+}
+
+for (const [label, address, memo, destinationType] of [
+    ['G with memo', G, {type: 'text', value: ' hello '}, 'account'],
+    ['C contract', C, null, 'contract'],
+    ['full M address', M, null, 'account']
+]) {
+    test(`show ${label} and link to its testnet page without automatic navigation`, async t => {
+        const ui = setup(t, () => Promise.resolve({name: 'alice.nova', address, memo}), ' Alice.NOVA ')
+        await ui.show()
+        assert.match(renderedText(ui.renderer), /Soran name: alice.nova/)
+        assert.match(renderedText(ui.renderer), new RegExp(address))
+        const links = ui.renderer.root.findAllByType('a')
+        assert(links.every(link => link.props.href === `/explorer/testnet/${destinationType}/${address}`))
+        assert.equal(ui.navigations.length, 0)
+        assert.equal(ui.standardSearches.length, 0)
+        if (memo) assert.equal(ui.renderer.root.findByType('code').children.join(''), ' hello ')
+    })
+}
+
+test('an absent namespace falls back to ordinary dotted asset/account search', async t => {
+    const ui = setup(t, () => Promise.reject(new SoranResolutionError('missing namespace', 5)), 'USD.token')
+    await ui.show()
+    assert.deepEqual(ui.standardSearches, [{type: 'account', query: 'USD.token'}, {type: 'assets', query: 'USD.token'}])
+    assert.equal(ui.renderer.root.findAllByProps({role: 'alert'}).length, 0)
+})
+
+for (const code of [7, 10, undefined]) {
+    test(`resolution error ${code} stays visible instead of becoming a search miss`, async t => {
+        const ui = setup(t, () => Promise.reject(new SoranResolutionError('Resolution unavailable', code)))
+        await ui.show()
+        assert.equal(ui.renderer.root.findByProps({role: 'alert'}).children.join(''), 'Resolution unavailable')
+        assert.equal(ui.standardSearches.length, 0)
+    })
+}
+
+test('late resolution cannot replace a newer search', async t => {
+    let finishFirst
+    const ui = setup(t, query => query === 'alice.nova' ? new Promise(resolve => {
+        finishFirst = resolve
+    }) :
+        Promise.resolve({name: query, address: C, memo: null}))
+    await ui.show()
+    await ui.show('cyclops.nova')
+    await act(async () => finishFirst({name: 'alice.nova', address: G, memo: null}))
+    assert.match(renderedText(ui.renderer), /Soran name: cyclops.nova/)
+    assert.doesNotMatch(renderedText(ui.renderer), /alice.nova/)
+})
+
+test('changing to public discards pending testnet reads and makes no new Soran request', async t => {
+    let finish
+    const ui = setup(t, () => new Promise(resolve => {
+        finish = resolve
+    }))
+    await ui.show()
+    await ui.show('alice.nova', 'public')
+    await act(async () => finish({name: 'alice.nova', address: G, memo: null}))
+    assert.equal(ui.resolutions.length, 1)
+    assert.doesNotMatch(renderedText(ui.renderer), /Soran name:/)
+    assert.equal(ui.standardSearches.length, 2)
+    assert.equal(ui.navigations.length, 0)
+})
+
+for (const network of ['testnet', 'public']) {
+    test(`existing federation resolution still searches its account on ${network}`, async t => {
+        const federation = t.mock.method(stellarSdk.Federation.Server, 'resolve', () => Promise.resolve({account_id: G}))
+        const ui = setup(t, () => assert.fail('Federation must not call Soran'), 'alice*example.org')
+        await ui.show('alice*example.org', network)
+        assert.equal(federation.mock.callCount(), 1)
+        assert.equal(ui.resolutions.length, 0)
+        assert.deepEqual(ui.standardSearches, [{type: 'account', query: G}, {type: 'assets', query: G}])
+    })
+
+    test(`existing .xlm resolution still searches its account on ${network}`, async t => {
+        const fetch = t.mock.method(globalThis, 'fetch', () => Promise.resolve({json: () => Promise.resolve({address: G})}))
+        const ui = setup(t, () => assert.fail('.xlm must not call Soran'), 'alice.xlm')
+        await ui.show('alice.xlm', network)
+        assert.equal(fetch.mock.callCount(), 1)
+        assert.equal(ui.resolutions.length, 0)
+        assert.deepEqual(ui.standardSearches, [{type: 'account', query: G}, {type: 'assets', query: G}])
+    })
+}

--- a/views/explorer/ledger/ledger-activity-view.js
+++ b/views/explorer/ledger/ledger-activity-view.js
@@ -1,59 +1,61 @@
 import React, {useCallback, useEffect, useState} from 'react'
-import {Amount, UpdateHighlighter, ledgerStream, retrieveLedgerInfo} from '@stellar-expert/ui-framework'
+import {Amount, UpdateHighlighter, ledgerStream, useStellarNetwork} from '@stellar-expert/ui-framework'
 import {apiCall} from '../../../models/api'
 import {resolvePath} from '../../../business-logic/path'
+import {parseLedgerResponse} from '../../../business-logic/ledger-info'
 import EmbedWidgetTrigger from '../widget/embed-widget-trigger'
 
-export default function LedgerActivityView({title, className}) {
-    let unmounted
-    let lastLedgerClosedAt = 0
-    const [ledgerInfo, setLedgerInfo] = useState({
-        sequence: 0,
-        txSuccess: 0,
-        txFailed: 0,
-        protocol: 0,
-        baseFee: 0,
-        baseReserve: 0,
-        timeDelta: 6
-    })
-
-    const processLedger = useCallback(ledger => {
-        if (unmounted)
-            return
-        ledger = retrieveLedgerInfo(ledger)
-        let timeDelta = 6
-        if (lastLedgerClosedAt) {
-            timeDelta = (ledger.ts - lastLedgerClosedAt)
-        }
-        lastLedgerClosedAt = ledger.ts
-        setLedgerInfo({
-            sequence: ledger.sequence,
-            protocol: ledger.protocol,
-            operations: ledger.operations,
-            txSuccess: ledger.txSuccess,
-            txFailed: ledger.txFailed,
-            baseFee: ledger.baseFee,
-            baseReserve: ledger.baseReserve,
-            timeDelta
-        })
-    }, [])
+export default function LedgerActivityView({title}) {
+    const network = useStellarNetwork()
+    const [ledgerInfo, setLedgerInfo] = useState(null)
+    const [error, setError] = useState(false)
+    const [retry, setRetry] = useState(0)
 
     useEffect(() => {
-        const onNewLedger = sequence => apiCall('ledger/' + sequence).then(processLedger)
+        let active = true
+        let previousLedger
+        setLedgerInfo(null)
+        setError(false)
+
+        function processLedger(data) {
+            if (!active) return
+            const ledger = parseLedgerResponse(data)
+            //Initial and streamed requests can finish out of order.
+            if (previousLedger && ledger.sequence <= previousLedger.sequence) return
+            const timeDelta = previousLedger ? ledger.ts - previousLedger.ts : 6
+            previousLedger = ledger
+            setLedgerInfo({...ledger, timeDelta})
+            setError(false)
+        }
+
+        function handleError() {
+            if (active) setError(true)
+        }
+
+        const onNewLedger = sequence => apiCall('ledger/' + sequence).then(processLedger).catch(handleError)
+        //Keep listening after an initial failure so a subsequent valid ledger can recover the panel.
+        ledgerStream.on(onNewLedger)
         ledgerStream.getLast()
-            .then(ledger => {
-                processLedger(ledger)
-                //start ledgers updates streaming
-                ledgerStream.on(onNewLedger)
-            })
+            .then(processLedger)
+            .catch(handleError)
 
         return () => {
-            unmounted = true
+            active = false
             ledgerStream.off(onNewLedger)
         }
+    }, [network, retry])
+
+    const retryLoading = useCallback(() => {
+        setRetry(value => value + 1)
     }, [])
 
-    if (!ledgerInfo.sequence)
+    if (error)
+        return <div role="alert" className="segment warning space">
+            <p>Live ledger data is unavailable.</p>
+            <button type="button" onClick={retryLoading}>Retry</button>
+        </div>
+
+    if (!ledgerInfo)
         return <div className="loader"/>
 
     return <>

--- a/views/explorer/ledger/ledger-view.js
+++ b/views/explorer/ledger/ledger-view.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import {BlockSelect, Amount, UtcTimestamp, InfoTooltip as Info} from '@stellar-expert/ui-framework'
-import {formatExplorerLink, useExplorerApi, usePageMetadata, retrieveLedgerInfo} from '@stellar-expert/ui-framework'
+import {formatExplorerLink, useExplorerApi, usePageMetadata} from '@stellar-expert/ui-framework'
 import appSettings from '../../../app-settings'
 import {resolvePath} from '../../../business-logic/path'
+import {parseLedgerResponse} from '../../../business-logic/ledger-info'
 import ErrorNotificationBlock from '../../components/error-notification-block'
 import CrawlerScreen from '../../components/crawler-screen'
 import Tracer from '../horizon-tracer/tracer-icon-view'
@@ -17,15 +18,20 @@ export default function LedgerView({match}) {
     })
     if (!ledgerInfo.loaded)
         return <div className="loader"/>
-    if (ledgerInfo.error || ledgerInfo.data.status) {
+    if (ledgerInfo.error || ledgerInfo.data?.error || ledgerInfo.data?.status) {
         let error = `Failed to load ledger ${sequence}.`
-        if (ledgerInfo.data.status === 404) {
+        if (ledgerInfo.status === 404 || ledgerInfo.data?.status === 404) {
             error = 'Ledger not found. The requested sequence is greater than the last known Horizon sequence.'
         }
         return <ErrorNotificationBlock>{error}</ErrorNotificationBlock>
     }
 
-    const ledger = retrieveLedgerInfo(ledgerInfo.data)
+    let ledger
+    try {
+        ledger = parseLedgerResponse(ledgerInfo.data)
+    } catch (error) {
+        return <ErrorNotificationBlock>Failed to load ledger {sequence}.</ErrorNotificationBlock>
+    }
 
     return <>
         <div style={{float: 'right', margin: '0.4em -0.4em 0px 0px', position: 'relative', zIndex: 1}}>

--- a/views/explorer/search/search-box-view.js
+++ b/views/explorer/search/search-box-view.js
@@ -3,6 +3,7 @@ import cn from 'classnames'
 import {navigation} from '@stellar-expert/ui-framework'
 import {detectSearchType} from '../../../business-logic/search'
 import {resolvePath} from '../../../business-logic/path'
+import appSettings from '../../../app-settings'
 
 export default function SearchBoxView({className, shrinkable, placeholder}) {
     const [value, setValue] = useState(navigation.query.search || '')
@@ -18,7 +19,7 @@ export default function SearchBoxView({className, shrinkable, placeholder}) {
         const term = value.trim()
         if (!term) return //prevent searching with empty term
         if (!force) { //proceed to search results page only if a user pressed Enter or autodiscovery detected search type
-            const searchTypes = detectSearchType(term)
+            const searchTypes = detectSearchType(term, appSettings.activeNetwork)
             if (searchTypes.length !== 1) return
         }
         navigation.navigate(resolvePath(`search?term=${encodeURIComponent(term)}`))
@@ -38,7 +39,9 @@ export default function SearchBoxView({className, shrinkable, placeholder}) {
     return <span className={cn('search-box', className, {shrinkable})}>
         <input value={value} onKeyUp={e => onKeyUp(e)} onChange={e => setValue(e.target.value.trim())}
                autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false"
-               placeholder={placeholder || 'Paste an asset code, tx hash, account address, or ledger sequence here'}/>
+               placeholder={placeholder || (appSettings.activeNetwork === 'testnet'
+                   ? 'Search by asset, transaction, address, ledger, or Soran name (alice.nova)'
+                   : 'Paste an asset code, tx hash, account address, or ledger sequence here')}/>
         <a href="#" className="icon icon-search" onClick={() => requestSearch(true)}/>
     </span>
 }

--- a/views/explorer/search/search-results-view.js
+++ b/views/explorer/search/search-results-view.js
@@ -1,9 +1,9 @@
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import {Federation} from '@stellar/stellar-sdk'
-import {useDependantState, usePageMetadata} from '@stellar-expert/ui-framework'
-import {navigation} from '@stellar-expert/ui-framework'
+import {navigation, useDependantState, usePageMetadata} from '@stellar-expert/ui-framework'
 import appSettings from '../../../app-settings'
 import {detectSearchType} from '../../../business-logic/search'
+import {resolveSoranName, SoranResolutionError} from '../../../business-logic/soran-resolution'
 import {resolvePath} from '../../../business-logic/path'
 import ErrorNotificationBlock from '../../components/error-notification-block'
 import AssetSearchResultsView from './assets-search-results-view'
@@ -13,6 +13,7 @@ import OperationSearchResultsView from './operation-search-results-view'
 import TransactionSearchResultsView from './transaction-search-results-view'
 import OfferSearchResultsView from './offer-search-results-view'
 import ContractSearchResultsView from './contract-search-results-view'
+import SoranSearchResultView from './soran-search-result-view'
 import './search.scss'
 
 /**
@@ -33,10 +34,20 @@ const searchTypesMapping = [
     {keys: ['asset', 'account'], component: AssetSearchResultsView}
 ]
 
-async function processSearchTerm(originalTerm) {
+async function processSearchTerm(originalTerm, network) {
     let term = originalTerm
     try {
-        let searchTypes = detectSearchType(originalTerm)
+        let searchTypes = detectSearchType(originalTerm, network)
+        if (searchTypes[0] === 'soran') {
+            try {
+                const resolution = await resolveSoranName(originalTerm, network, appSettings.networks[network])
+                return {term, originalTerm, resolution, searchTypes: [], error: null}
+            } catch (error) {
+                //An unallocated namespace may instead be an asset code or ordinary search text.
+                if (!(error instanceof SoranResolutionError) || error.code !== 5) throw error
+                searchTypes = ['account', 'asset']
+            }
+        }
         //resolve federation address
         if (searchTypes[0] === 'federation') {
             const {account_id} = await Federation.Server.resolve(originalTerm)
@@ -54,6 +65,7 @@ async function processSearchTerm(originalTerm) {
 
     } catch (e) {
         console.error(e)
+        if (e instanceof SoranResolutionError) return {term, error: e.message}
         return {term, results: [], error: `Nothing found for search term "${term}".`}
     }
 }
@@ -77,15 +89,15 @@ function SearchResults({term, searchTypes, originalTerm}) {
             .then(allResults => {
                 const nonEmpty = allResults.flat().filter(res => !!res)
                 switch (nonEmpty.length) {
-                    case 0:
-                        setNotFound(true)
-                        break
-                    case 1:
-                        navigation.navigate(nonEmpty[0].link) //navigate to the default result
-                        break
-                    default:
-                        setNotFound(false)
-                        break
+                case 0:
+                    setNotFound(true)
+                    break
+                case 1:
+                    navigation.navigate(nonEmpty[0].link) //navigate to the default result
+                    break
+                default:
+                    setNotFound(false)
+                    break
                 }
             })
         return components
@@ -95,55 +107,61 @@ function SearchResults({term, searchTypes, originalTerm}) {
         {componentsToRender}
         {typeof notFound !== 'boolean' && <div className="loader"/>}
         {!!notFound && <div className="notfound text-center double-space dimmed">
-            Not found "{originalTerm}"
+            Not found &quot;{originalTerm}&quot;
         </div>}
     </div>
 }
 
 function SearchResultsWrapper({originalTerm, children}) {
     return <div className="search container narrow">
-        <h2 className="text-overflow">Search results for "{originalTerm}"</h2>
+        <h2 className="text-overflow">Search results for &quot;{originalTerm}&quot;</h2>
         {children}
     </div>
 }
 
 export default function SearchResultsView() {
     const originalTerm = (navigation.query.term || '').trim()
+    const network = appSettings.activeNetwork
     usePageMetadata({
         title: `Search "${originalTerm}"`,
         description: `Search results for term "${originalTerm}" on Stellar ${appSettings.activeNetwork} network.`
     })
 
-    const [state, setState] = useDependantState(() => {
-        processSearchTerm(originalTerm)
-            .then(newState => setState(newState))
-
-        return {
-            searchTypes: [],
-            term: '',
-            originalTerm: '',
-            error: null,
-            inProgress: true
+    const [state, setState] = useState(null)
+    useEffect(() => {
+        let active = true
+        setState(null)
+        processSearchTerm(originalTerm, network).then(result => {
+            if (active) setState({originalTerm, network, result})
+        })
+        return () => {
+            active = false
         }
-    }, [originalTerm])
+    }, [originalTerm, network])
 
-    if (state.error)
+    //Do not show a previous query's result or apply a late testnet read after changing networks.
+    if (!state || state.originalTerm !== originalTerm || state.network !== network) return <div className="loader"/>
+    const result = state.result
+
+    if (result.error)
         return <SearchResultsWrapper originalTerm={originalTerm}>
-            <ErrorNotificationBlock>{state.error}</ErrorNotificationBlock>
+            <ErrorNotificationBlock>{result.error}</ErrorNotificationBlock>
         </SearchResultsWrapper>
-
-    if (state.inProgress)
-        return <div className="loader"/>
 
     if (!originalTerm)
         return <SearchResultsWrapper originalTerm={originalTerm}>
             <div className="text-center dimmed">(no search term provided)</div>
         </SearchResultsWrapper>
 
+    if (result.resolution)
+        return <SearchResultsWrapper originalTerm={originalTerm}>
+            <SoranSearchResultView resolution={result.resolution}/>
+        </SearchResultsWrapper>
+
     return <SearchResultsWrapper originalTerm={originalTerm}>
-        <SearchResults {...state}/>
+        <SearchResults key={`${network}:${originalTerm}`} {...result}/>
         <div className="space segment blank">
-            <h3>Not found what you've been looking for?</h3>
+            <h3>Not found what you&apos;ve been looking for?</h3>
             <hr className="flare"/>
             <div className="row">
                 <div className="column column-66 space">

--- a/views/explorer/search/soran-search-result-view.js
+++ b/views/explorer/search/soran-search-result-view.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import {StrKey} from '@stellar/stellar-sdk'
+import {resolvePath} from '../../../business-logic/path'
+
+export default function SoranSearchResultView({resolution}) {
+    const {name, address, memo} = resolution
+    const isContract = StrKey.isValidContract(address)
+    const link = resolvePath(`${isContract ? 'contract' : 'account'}/${address}`)
+    return <div className="segment blank space">
+        <h3>Soran name: {name}</h3>
+        <p>{isContract ? 'Contract' : 'Account'} destination on testnet:</p>
+        <p style={{overflowWrap: 'anywhere'}}><a href={link}>{address}</a></p>
+        {!!memo && <p>Required memo ({memo.type}):{' '}
+            <code style={{whiteSpace: 'pre-wrap', overflowWrap: 'anywhere'}}>{memo.value}</code>
+        </p>}
+        {StrKey.isValidMed25519PublicKey(address) && <p className="dimmed">
+            The routing ID is included in this full muxed address.
+        </p>}
+        <a href={link}>View {isContract ? 'contract' : 'account'} activity</a>
+    </div>
+}


### PR DESCRIPTION
# Add Soran testnet name resolution through Stellar RPC

Testnet search now resolves Soran names such as `alice.nova` through the Universal Lookup contract using the existing Stellar SDK. The result shows the canonical name, complete account or contract destination, and any required memo. Muxed destinations retain the full routing ID in their M address. The result stays visible before opening account activity so memo information is preserved.

Resolution uses unsigned Stellar RPC simulations, with no Soran HTTP API, Soran SDK, wallet, or transaction submission. It checks the Registry anchor and destination ABI before resolving, strictly validates the XDR response, and keeps restoration, transport, dependency, and malformed-result failures distinct from missing names. Namespace discovery supports `.nova`, `.orange`, and other Soran namespaces without maintaining individual Resolver addresses.

The integration is limited to testnet forward search. Public-network behavior, federation, and `.xlm` resolution remain intact. An explicitly missing namespace falls back to ordinary account/asset text search. Query changes and network switches discard late resolution responses.

The live-ledger panel and ledger-details page also handle failed API responses and missing or malformed headers. The panel catches loading failures, offers Retry, and recovers when valid stream data arrives. Late responses cannot overwrite a newer ledger or reattach listeners after unmounting. This repair is in a separate commit from the Soran integration.

Raw storage keys and payment encodings are documented in `docs/soran-resolution.md`, including a live `alice.nova` snapshot. Raw address entries alone cannot preserve payment routing or establish current validity: generations, expiry, namespace routing, and archived storage also matter. This implementation leaves those checks in Lookup. The anchor/ABI checks do not pin executable hashes, and testnet deployment configuration may need updating after upgrades or resets.

## Validation

- `pnpm test`: 85 passing tests. Includes 12 published valid destination fixtures and 23 rejection fixtures, u64/UTF-8 boundaries, deployment checks, restoration and transport failures, rendered destinations and memos, namespace fallback, stale responses, network switches, federation/`.xlm` regressions, and ledger loading/error recovery.
- `pnpm build`: successful; webpack reports three asset-size, entrypoint-size, and runtime-chunk warnings.
- ESLint on changed JavaScript and tests: zero errors; warnings remain on existing patterns in app settings, the search input, and the ledger-details view.
- `git diff --check`: clean.
- Live RPC checks on 12 September 2026: `alice.nova`, `nikcle.nova`, `robert.nova`, `echo.nova`, `mux.nova`, `cyclops.nova`, `mux.orange`, and `robert.orange` resolved successfully. An unregistered `.nova` name returned Lookup error 7.
- Raw ledger inspection confirmed `alice.nova`'s current Registrar record, address record, payment text, and configured-generation marker.
- Local development server checks: account details, transaction history (eight records for the `alice.nova` destination), latest ledger, and public asset statistics return HTTP 200. A local API proxy configuration is kept outside the repository; the normal account/history implementation is unchanged.

Browser smoke testing remains outstanding: the browser tool could not verify an administrator-enforced access policy for localhost, so access was not granted. React interaction tests and the production build passed. Manual browser checks are listed in the integration document.

## References

- [On-chain resolution](https://docs.soran.domains/api/onchain-resolution)
- [Storage reference](https://docs.soran.domains/reference/contract-storage)
- [Current testnet deployment](https://docs.soran.domains/reference/release-status)
- [Decoder conformance fixtures](https://docs.soran.domains/reference/lookup-decoding)
